### PR TITLE
feat: KanbanColumn 컴포넌트 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,42 @@
 import { useState } from 'react'
-import KanbanItem from './components/KanbanItem'
+import KanbanColumn from './components/KanbanColumn'
+
+const DUMMY_ITEMS = [
+  { id: 1, content: '첫번째' },
+  { id: 2, content: '두번째' },
+  { id: 3, content: '세번째' },
+]
 
 function App() {
-  const [content, setContent] = useState('kanban item')
-  const updateContent = (nextContent) => setContent(nextContent)
+  const [kanbanItems, setKanbanItems] = useState(DUMMY_ITEMS)
+  const [title, setTitle] = useState('kanban title')
+  const updateTitle = (nextTitle) => setTitle(nextTitle)
+  const updateContent = (id, nextContent) => {
+    const nextKanbanItems = kanbanItems.map((item) => {
+      if (item.id !== id) {
+        return item
+      }
 
-  return <KanbanItem content={content} updateContent={updateContent} />
+      return { ...item, content: nextContent }
+    })
+
+    setKanbanItems(nextKanbanItems)
+  }
+  const addKanbanItem = () =>
+    setKanbanItems([
+      ...kanbanItems,
+      { id: kanbanItems.at(-1).id + 1, content: '새로운 카드' },
+    ])
+
+  return (
+    <KanbanColumn
+      title={title}
+      kanbanList={kanbanItems}
+      updateTitle={updateTitle}
+      updateContent={updateContent}
+      addKanbanItem={addKanbanItem}
+    />
+  )
 }
 
 export default App

--- a/src/components/KanbanColumn.js
+++ b/src/components/KanbanColumn.js
@@ -1,0 +1,103 @@
+import styled from '@emotion/styled'
+import { useEffect, useRef, useState } from 'react'
+import KanbanItem from './KanbanItem'
+
+const KanbanColumn = ({
+  title,
+  kanbanList,
+  updateTitle,
+  updateContent,
+  addKanbanItem,
+}) => {
+  const inputRef = useRef(null)
+  const [isEditMode, setIsEditMode] = useState(false)
+  const [inputTitle, setInputTitle] = useState(title)
+  const handleChange = (e) => {
+    setInputTitle(e.target.value)
+  }
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      setInputTitle(title)
+      setIsEditMode(false)
+      return
+    }
+
+    /** 내용이 공백으로 수정은 안됨 */
+    if (e.target.value === '') {
+      return
+    }
+
+    if (e.key === 'Enter') {
+      updateTitle(inputTitle)
+      setIsEditMode(false)
+    }
+  }
+
+  useEffect(() => {
+    if (isEditMode) {
+      inputRef.current.focus()
+    }
+  }, [isEditMode])
+
+  return (
+    <Container>
+      <Title onClick={() => setIsEditMode(true)} isEditMode={isEditMode}>
+        {title}
+      </Title>
+      <Input
+        ref={inputRef}
+        isEditMode={isEditMode}
+        value={inputTitle}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onBlur={() => {
+          setInputTitle(title)
+          setIsEditMode(false)
+        }}
+      />
+      <KanbanList>
+        {kanbanList.map(({ id, content }) => (
+          <KanbanItem
+            key={id}
+            id={id}
+            content={content}
+            updateContent={updateContent}
+          />
+        ))}
+      </KanbanList>
+      <AddButton onClick={addKanbanItem}>+ Add a card</AddButton>
+    </Container>
+  )
+}
+
+const Container = styled.div`
+  width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 16px;
+`
+
+const Title = styled.div`
+  display: ${(props) => (props.isEditMode ? 'none' : 'block')};
+  font-weight: bold;
+`
+
+const Input = styled.input`
+  display: ${(props) => (props.isEditMode ? 'block' : 'none')};
+  width: 100%;
+  height: 100%;
+  border: solid 2px;
+`
+
+const KanbanList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`
+
+const AddButton = styled.button`
+  cursor: pointer;
+`
+
+export default KanbanColumn

--- a/src/components/KanbanItem.js
+++ b/src/components/KanbanItem.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { useEffect, useRef, useState } from 'react'
 
-function KanbanItem({ content, updateContent }) {
+function KanbanItem({ id, content, updateContent }) {
   const inputRef = useRef(null)
   const [isEditMode, setIsEditMode] = useState(false)
   const [inputContent, setInputContent] = useState(content)
@@ -21,7 +21,7 @@ function KanbanItem({ content, updateContent }) {
     }
 
     if (e.key === 'Enter') {
-      updateContent(inputContent)
+      updateContent(id, inputContent)
       setIsEditMode(false)
     }
   }


### PR DESCRIPTION
# 작업내용
- `KanbanColumn 컴포넌트 구현`
- `title` 렌더링 및 수정
- `KanbanItem` 렌더링
- 새로운 `KanbanItem` 생성 버튼 추가
- `updateContent` `id` 기준으로 동작하도록 수정
<img width="309" alt="스크린샷 2022-09-15 오후 4 31 34" src="https://user-images.githubusercontent.com/16220817/190342875-2baca56a-bdf4-4bfc-8361-187f5025069d.png">
<img width="288" alt="스크린샷 2022-09-15 오후 4 31 42" src="https://user-images.githubusercontent.com/16220817/190342897-18240f6b-058c-47e5-bb85-a98cfefc04a5.png">

close #2