### PR TITLE
fix: KanbanItem이 5개 이상이면 스크롤 가능하게 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,8 +5,6 @@ import KanbanColumn from './components/KanbanColumn'
 import { getItem, setItem } from './utils/store'
 
 const LOCAL_KANBAN_COLUMN = 'KANBAN_COLUMNS'
-/** KanbanColumn이 5개 이상이면 스크롤이 가능해야함 */
-const X_SCROLL_COLUM_SIZE = 5
 const MIN_KANBAN_COLUMN_SIZE = 2
 const DEFAULT_KANBAN_COLUMNS = [
   {
@@ -275,6 +273,5 @@ const Container = styled.div`
   display: flex;
   gap: 24px;
   padding: 16px 16px;
-  overflow-x: ${({ kanbanColumnSize }) =>
-    kanbanColumnSize >= X_SCROLL_COLUM_SIZE ? 'scroll' : 'hidden'};
+  overflow-x: auto;
 `

--- a/src/components/KanbanColumn.js
+++ b/src/components/KanbanColumn.js
@@ -4,6 +4,9 @@ import AddButton from './AddButton'
 import DeleteButton from './DeleteButton'
 import KanbanItem from './KanbanItem'
 
+/** KanbanItem이 5개 이상이면 스크롤이 가능해야함 */
+const SCROLL_ITEM_SIZE = 5
+
 const KanbanColumn = ({
   id,
   title,
@@ -90,7 +93,7 @@ const KanbanColumn = ({
         <DeleteButton onDelete={() => deleteKanbanColumn(id)} />
       </Header>
 
-      <KanbanList>
+      <KanbanList kanbanListSize={kanbanList.length}>
         {kanbanList.map(({ id: itemId, content }) => (
           <KanbanItem
             key={itemId}
@@ -144,9 +147,12 @@ const Input = styled.input`
 `
 
 const KanbanList = styled.div`
+  max-height: 200px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  overflow-y: ${({ kanbanListSize }) =>
+    kanbanListSize >= SCROLL_ITEM_SIZE ? 'scroll' : 'hidden'};
 `
 
 export default KanbanColumn

--- a/src/components/KanbanItem.js
+++ b/src/components/KanbanItem.js
@@ -91,6 +91,7 @@ function KanbanItem({
 export default KanbanItem
 
 const Container = styled.div`
+  flex-shrink: 0;
   box-sizing: border-box;
   width: 100%;
   height: 40px;


### PR DESCRIPTION
# 작업한 내용
- `KanbanItem`이 5개 이상이면 스크롤 가능하게 수정
  - 기존에는 `KanbanColumn`이 5개 이상일 때 스크롤 가능하도록 잘못 적용했었음. (#15)

https://user-images.githubusercontent.com/16220817/190589678-0cf34012-986b-49a7-b272-ac3965c97945.mov

close #18 